### PR TITLE
add strict guava dependency. update grpc and protobuf version

### DIFF
--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8
-        uses: actions/setup-java@v1.3.0
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: 8
       - name: Build with Gradle

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8
-        uses: actions/setup-java@v1.3.0
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: 8
       - name: Build with Gradle

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1.3.0
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: 8
       - name: Build with Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,8 +25,8 @@ java {
     withJavadocJar()
 }
 
-val protobufVersion = "3.11.4"
-val grpcVersion = "1.32.1"
+val protobufVersion = "3.14.0"
+val grpcVersion = "1.34.0"
 
 dependencies {
     api("com.google.protobuf:protobuf-java:$protobufVersion")


### PR DESCRIPTION
I was merging a few update PRs and Snyk detected a vulnerability in the project - specifically guava, transitive dependency of grpc. 

This is the vulnerability. 

https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415

The latest stable version grpc and protobuf-java still depend on guava 29. So, I forced guava to be version 30 instead. Tested locally with Snyk and it now passes. 

Not sure if this is the right way to approach this. Feedback welcome!